### PR TITLE
refactor: enhance SimpleDML class with sharing and access control

### DIFF
--- a/sfdx-source/fflib-apex-common-subset/main/classes/fflib_SObjectUnitOfWork.cls
+++ b/sfdx-source/fflib-apex-common-subset/main/classes/fflib_SObjectUnitOfWork.cls
@@ -105,9 +105,6 @@ public virtual class fflib_SObjectUnitOfWork
         }
         public virtual void dmlDelete(List<SObject> objList)
         {
-            if(!objList.isEmpty() && !objList[0].getSObjectType().getDescribe().isDeletable()) {
-                throw new System.NoAccessException();
-            }
             Database.delete(objList, AccessLevel.USER_MODE);
         }
         public virtual void eventPublish(List<SObject> objList)

--- a/sfdx-source/fflib-apex-common-subset/main/classes/fflib_SObjectUnitOfWork.cls
+++ b/sfdx-source/fflib-apex-common-subset/main/classes/fflib_SObjectUnitOfWork.cls
@@ -93,19 +93,22 @@ public virtual class fflib_SObjectUnitOfWork
 	    void emptyRecycleBin(List<SObject> objList);
     }
 
-    public virtual class SimpleDML implements IDML
+    public with sharing virtual class SimpleDML implements IDML
     {
         public virtual void dmlInsert(List<SObject> objList)
         {
-            insert objList;
+            Database.insert(objList, AccessLevel.USER_MODE);
         }
         public virtual void dmlUpdate(List<SObject> objList)
         {
-            update objList;
+            Database.update(objList, AccessLevel.USER_MODE);
         }
         public virtual void dmlDelete(List<SObject> objList)
         {
-            delete objList;
+            if(!objList.isEmpty() && !objList[0].getSObjectType().getDescribe().isDeletable()) {
+                throw new System.NoAccessException();
+            }
+            Database.delete(objList, AccessLevel.USER_MODE);
         }
         public virtual void eventPublish(List<SObject> objList)
         {


### PR DESCRIPTION
Updated the SimpleDML class to enforce sharing rules and added access control for delete operations. Replaced direct DML statements with Database methods to ensure proper access levels are applied.